### PR TITLE
Increase timeout for waiting on llama-server from 180 to 360 seconds

### DIFF
--- a/rinna/transformer_models.py
+++ b/rinna/transformer_models.py
@@ -81,7 +81,7 @@ if is_llama_server_mode:
         start_new_session=True,
     )
 
-    def _wait_for_server(url, timeout=180):
+    def _wait_for_server(url, timeout=360):
         logger.info('Waiting for llama-server to start...')
         from time import sleep as _sleep
         _sleep(3)


### PR DESCRIPTION
## Summary

- llama-serverの起動待ちタイムアウトを180秒から360秒に延長

## Test plan

- [ ] llama-serverが正常起動するまで最大360秒待つことを確認