### PR TITLE
Fix CI error by restricting pytest to tests/ directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ name = "torch_rocm61"
 url = "https://download.pytorch.org/whl/rocm6.1"
 priority = "explicit"
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary

- `bin/test_proxy.py` に `test_` で始まる関数が定義されており、pytest が誤って収集していた
- `test_proxy_client(proxy_url: str)` が pytest fixture として解決できない `proxy_url` パラメータを要求し、CI が失敗していた
- `pyproject.toml` に `[tool.pytest.ini_options]` セクションを追加し、`testpaths = ["tests"]` を設定して `tests/` ディレクトリのみを対象にするよう修正

## Test plan

- [ ] CI が全テストパスすることを確認
- [ ] `bin/test_proxy.py` が pytest の収集対象から除外されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vnint78eT5mdbgeMAT3qy4