### PR TITLE
Add vision support for Slack image attachments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,10 @@ full correspondence table and manual-sync procedure with that sibling repo. In s
 - **`rinna-signal`** fires on an explicit persona mention or an autonomous heuristic (recent
   activity, cooldown, random chance — all decided on the sibling repo's side). Payload:
   `{type: 'rinna-signal', humanMessages, botMessages, lastSignal}`, where `humanMessages` is a
-  15-minute sliding window of Slack messages.
+  15-minute sliding window of Slack messages. `slack.ts` pushes the raw Slack event `message`
+  object into this window with no field-picking, so any `files` (image attachments) Slack sends
+  on a message are already present in the payload today — no sibling-repo change was needed to
+  add vision support, only extending this repo's `humanMessageSchema` to stop discarding `files`.
 - **`rinna-meaning`** fires when TSG slackbot posts a message ending in `わからん`. Payload:
   `{type: 'rinna-meaning', word, ts}`.
 - **`rinna-temperature`** fires on any message with text `うなの体温`.
@@ -79,7 +82,18 @@ speech, and moderation results.
 - `prompt/buildPrompt.ts` — builds the "intro + dialogue so far" prompt for a persona, growing the
   included history one message at a time (newest-first) until the token budget
   (`MAX_PROMPT_TOKENS=11500`, `MAX_HISTORY_TOKENS=2000`) would be exceeded, then keeping the last
-  window that fit. Takes an injected `tokenize` function so it never touches the network.
+  window that fit. Takes an injected `tokenize` function so it never touches the network. Also
+  takes an optional `extraSuffix` string, inserted right before the persona's speech-opening 「 —
+  used to attach image markers (see `prompt/imageAttachments.ts` below) without buildPrompt itself
+  knowing anything about images.
+- `prompt/imageAttachments.ts` — `selectRecentImageUrls` scans a message window for `files` with an
+  `image/*` mimetype and keeps only the most recent `maxImages` (the count comes from
+  `AppDependencies.maxRecentImages`, sourced from `MAX_RECENT_IMAGES`, default 3), returned oldest
+  kept image first. `IMAGE_MEDIA_MARKER = '<__media__>'` is llama.cpp's mtmd marker string; note
+  that image markers can **not** be embedded directly into a message's own `.text` because
+  `normalizeText` (used when formatting dialogue) strips any `<...>` tag (it exists to strip
+  Slack's `<@mention>`/`<#channel>`/`<url>` syntax) — that's why marker insertion happens via
+  buildPrompt's `extraSuffix` instead, applied once per generation rather than per-message.
 - `speech/streamParser.ts` — consumes raw LLM text pieces and yields complete sentences as their
   delimiter is confirmed (not mid-run of `！？`, not inside a bracket/quote).
 - `speech/splitChunks.ts` — the non-streaming counterpart, used by the `@うな先生` meaning flow.
@@ -90,15 +104,32 @@ speech, and moderation results.
 
 ### Ports (`src/ports/`) and adapters (`src/adapters/`)
 
-`LlmClient`, `ChatPoster`, `Moderator`, `ResponseLog`, `MessageSource`/`Publisher`, `Thermometer`,
-`Clock`, `Random` are the interfaces `app/` handlers depend on. Concrete implementations:
+`LlmClient`, `ChatPoster`, `ImageDownloader`, `Moderator`, `ResponseLog`, `MessageSource`/`Publisher`,
+`Thermometer`, `Clock`, `Random` are the interfaces `app/` handlers depend on. Concrete
+implementations:
 
 - `LlamaServerClient` + `llamaServerProcess.ts` — spawns and health-checks the `llama-server`
   binary (path from `LLAMA_SERVER_BINARY`, default `~/Documents/GitHub/llama.cpp/build/bin/llama-server`),
   then talks to it over HTTP. `streamGenerate` tracks `「`/`」` nesting depth itself to stop
   generation exactly at the outer speech's closing bracket, without cutting off a quoted word
-  inside the speech.
-- `modelDownloader.ts` — pulls the GGUF from Hugging Face Hub via `@huggingface/hub`.
+  inside the speech. `llamaServerProcess.ts` always starts the binary with `--mmproj` (path from
+  `MMPROJ_FILE`, downloaded from the same `MODEL_REPO`), so vision is loaded unconditionally —
+  this costs ~3GB of idle VRAM even for text-only replies. `LlmClient.generate`/`streamGenerate`
+  take a `GenerateInput` union: `{tokenIds}` for the normal pre-tokenized text path, or
+  `{promptText, images}` (base64 strings) for llama-server's multimodal `/completion` shape
+  (`prompt: {prompt_string, multimodal_data}` — the current llama.cpp server API, not the older
+  `image_data` field some docs still reference). Marker count in `prompt_string` and
+  `multimodal_data.length` must match exactly or the server 500s.
+- `modelDownloader.ts` — pulls the GGUF (and the mmproj file) from Hugging Face Hub via
+  `@huggingface/hub`.
+- `SlackImageDownloader` — downloads a Slack `url_private` with `Authorization: Bearer
+  <SLACK_TOKEN>` (Slack's Web API has no RPC for file bytes, so this is a plain `fetch`, unlike
+  `SlackChatPoster`'s use of `@slack/web-api`'s `WebClient`), then re-encodes with `sharp`: EXIF
+  auto-rotate, downscale to fit inside `MAX_IMAGE_DIMENSION=2048` per side (keeps
+  width×height under llama.cpp mtmd's `image_max_pixels` hparam for this model), re-encoded as
+  JPEG. This also sidesteps format edge cases (CMYK JPEGs, animated GIFs, etc.) that llama.cpp's
+  `stb_image`-based decoder rejects with `"failed to process image"` — real-world Slack uploads
+  hit this more often than the pixel-count limit alone would suggest.
 - `SlackChatPoster`, `GoogleLanguageModerator`, `AzureContentModerator` (+ `ParallelModerator` to
   run both concurrently), `FirestoreResponseLog`, `PubSubClient`, `RocmSmiThermometer`.
 
@@ -107,7 +138,11 @@ speech, and moderation results.
 - `handlers/signalHandler.ts` — the core chat flow: thread-reply logic for stale triggers,
   `/clear`/`/no_clear`, then either the `@うな先生` meaning flow or firing each mentioned persona
   in turn (each one's reply is appended to the running history before the next persona generates,
-  so multiple personas mentioned in one message "see" each other's replies).
+  so multiple personas mentioned in one message "see" each other's replies). Also selects and
+  downloads (via `ImageDownloader`) the most recent `maxRecentImages` Slack images from the
+  window once per signal, before the persona loop, so every persona mentioned by the same message
+  sees the same images (the `@うな先生` meaning flow doesn't get images — `rinna-meaning`'s payload
+  carries only `{word, ts}`, no message history).
 - `handlers/meaningHandler.ts` — the `@うな先生` / `rinna-meaning` flow. Always sleeps 1s before
   posting every chunk, including the first (unlike the persona-response flow, which skips the
   sleep before its first chunk).

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"async-mutex": "^0.5.0",
 				"dotenv": "^17.4.2",
 				"firebase-admin": "^14.1.0",
+				"sharp": "^0.35.3",
 				"yaml": "^2.9.0",
 				"zod": "^4.4.3"
 			},
@@ -99,9 +100,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -119,9 +117,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -139,9 +134,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -159,9 +151,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -221,7 +210,6 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
 			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1062,6 +1050,506 @@
 				"gearhash-jit": "1.0.2"
 			}
 		},
+		"node_modules/@img/colour": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+			"integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@img/sharp-darwin-arm64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+			"integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-arm64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-darwin-x64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+			"integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-x64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-freebsd-wasm32": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+			"integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"dependencies": {
+				"@img/sharp-wasm32": "0.35.3"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-arm64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+			"integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-x64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+			"integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+			"integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+			"cpu": [
+				"arm"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+			"integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-ppc64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+			"integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-riscv64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+			"integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-s390x": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+			"integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-x64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+			"integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+			"cpu": [
+				"x64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+			"integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+			"integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+			"integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+			"cpu": [
+				"arm"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+			"integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linux-ppc64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+			"integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-ppc64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linux-riscv64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+			"integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-riscv64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linux-s390x": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+			"integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-s390x": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linux-x64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+			"integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-x64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-arm64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+			"integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-x64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+			"integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+			}
+		},
+		"node_modules/@img/sharp-wasm32": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+			"integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/runtime": "^1.11.1"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-webcontainers-wasm32": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+			"integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+			"cpu": [
+				"wasm32"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@img/sharp-wasm32": "0.35.3"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-arm64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+			"integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-ia32": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+			"integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-x64": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+			"integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1363,9 +1851,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1383,9 +1868,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1403,9 +1885,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1423,9 +1902,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1443,9 +1919,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1463,9 +1936,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2515,7 +2985,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
 			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
@@ -3808,9 +4277,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3832,9 +4298,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3856,9 +4319,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3880,9 +4340,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -4563,6 +5020,55 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/sharp": {
+			"version": "0.35.3",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+			"integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@img/colour": "^1.1.0",
+				"detect-libc": "^2.1.2",
+				"semver": "^7.8.5"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-darwin-arm64": "0.35.3",
+				"@img/sharp-darwin-x64": "0.35.3",
+				"@img/sharp-freebsd-wasm32": "0.35.3",
+				"@img/sharp-libvips-darwin-arm64": "1.3.2",
+				"@img/sharp-libvips-darwin-x64": "1.3.2",
+				"@img/sharp-libvips-linux-arm": "1.3.2",
+				"@img/sharp-libvips-linux-arm64": "1.3.2",
+				"@img/sharp-libvips-linux-ppc64": "1.3.2",
+				"@img/sharp-libvips-linux-riscv64": "1.3.2",
+				"@img/sharp-libvips-linux-s390x": "1.3.2",
+				"@img/sharp-libvips-linux-x64": "1.3.2",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+				"@img/sharp-linux-arm": "0.35.3",
+				"@img/sharp-linux-arm64": "0.35.3",
+				"@img/sharp-linux-ppc64": "0.35.3",
+				"@img/sharp-linux-riscv64": "0.35.3",
+				"@img/sharp-linux-s390x": "0.35.3",
+				"@img/sharp-linux-x64": "0.35.3",
+				"@img/sharp-linuxmusl-arm64": "0.35.3",
+				"@img/sharp-linuxmusl-x64": "0.35.3",
+				"@img/sharp-webcontainers-wasm32": "0.35.3",
+				"@img/sharp-win32-arm64": "0.35.3",
+				"@img/sharp-win32-ia32": "0.35.3",
+				"@img/sharp-win32-x64": "0.35.3"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"async-mutex": "^0.5.0",
 		"dotenv": "^17.4.2",
 		"firebase-admin": "^14.1.0",
+		"sharp": "^0.35.3",
 		"yaml": "^2.9.0",
 		"zod": "^4.4.3"
 	},

--- a/src/adapters/LlamaServerClient.ts
+++ b/src/adapters/LlamaServerClient.ts
@@ -1,4 +1,8 @@
-import type {GenerationConfig, LlmClient} from '../ports/LlmClient.js';
+import type {
+	GenerateInput,
+	GenerationConfig,
+	LlmClient,
+} from '../ports/LlmClient.js';
 
 export interface LlamaServerClientOptions {
 	readonly baseUrl: string;
@@ -13,6 +17,18 @@ const SAMPLING_PARAMS = {
 	top_k: 30,
 	repeat_penalty: 1.2,
 };
+
+/** Builds the /completion `prompt` field: a plain token array for the
+ * text-only path, or a {prompt_string, multimodal_data} object when images
+ * are attached (llama-server's multimodal prompt shape). */
+function buildPromptField(
+	input: GenerateInput,
+):
+	| readonly number[]
+	| {prompt_string: string; multimodal_data: readonly string[]} {
+	if ('tokenIds' in input) return input.tokenIds;
+	return {prompt_string: input.promptText, multimodal_data: input.images};
+}
 
 async function* readSseLines(
 	body: ReadableStream<Uint8Array>,
@@ -68,13 +84,13 @@ export class LlamaServerClient implements LlmClient {
 	}
 
 	async generate(
-		tokenIds: readonly number[],
+		input: GenerateInput,
 	): Promise<{output: string; config: GenerationConfig}> {
 		const response = await fetch(`${this.options.baseUrl}/completion`, {
 			method: 'POST',
 			headers: {'Content-Type': 'application/json'},
 			body: JSON.stringify({
-				prompt: tokenIds,
+				prompt: buildPromptField(input),
 				n_predict: 200,
 				stop: ['」'],
 				...SAMPLING_PARAMS,
@@ -93,13 +109,13 @@ export class LlamaServerClient implements LlmClient {
 	}
 
 	async *streamGenerate(
-		tokenIds: readonly number[],
+		input: GenerateInput,
 	): AsyncGenerator<string, void, undefined> {
 		const response = await fetch(`${this.options.baseUrl}/completion`, {
 			method: 'POST',
 			headers: {'Content-Type': 'application/json'},
 			body: JSON.stringify({
-				prompt: tokenIds,
+				prompt: buildPromptField(input),
 				n_predict: 200,
 				stream: true,
 				...SAMPLING_PARAMS,

--- a/src/adapters/SlackImageDownloader.ts
+++ b/src/adapters/SlackImageDownloader.ts
@@ -1,0 +1,49 @@
+import sharp from 'sharp';
+import type {ImageDownloader} from '../ports/ImageDownloader.js';
+
+/** Caps the resized image at this many pixels per side (fit: inside, so the
+ * actual width*height stays comfortably under llama-server's mmproj
+ * image_max_pixels=4194304 for this model regardless of aspect ratio).
+ * Oversized/exotic-format Slack uploads (large photos, CMYK JPEGs, animated
+ * GIFs, ...) are the main cause of mtmd's "failed to process image" 500s. */
+const MAX_IMAGE_DIMENSION = 2048;
+const JPEG_QUALITY = 85;
+
+/** Slack's Web API has no RPC for fetching file bytes; url_private is a
+ * plain authenticated GET (Authorization: Bearer <token>). The response is
+ * re-encoded to a size- and format-normalized JPEG so llama.cpp's mtmd image
+ * decoder — which has narrower format/size support than real-world Slack
+ * uploads — doesn't choke on it. */
+export class SlackImageDownloader implements ImageDownloader {
+	constructor(private readonly token: string) {}
+
+	async downloadBase64(url: string): Promise<string> {
+		const response = await fetch(url, {
+			headers: {Authorization: `Bearer ${this.token}`},
+		});
+		if (!response.ok) {
+			throw new Error(
+				`Slack file download returned ${response.status}: ${url}`,
+			);
+		}
+		const buffer = Buffer.from(await response.arrayBuffer());
+
+		try {
+			const resized = await sharp(buffer)
+				.rotate()
+				.resize({
+					width: MAX_IMAGE_DIMENSION,
+					height: MAX_IMAGE_DIMENSION,
+					fit: 'inside',
+					withoutEnlargement: true,
+				})
+				.jpeg({quality: JPEG_QUALITY})
+				.toBuffer();
+			return resized.toString('base64');
+		} catch (error) {
+			throw new Error(
+				`Failed to normalize downloaded image (${url}): ${(error as Error).message}`,
+			);
+		}
+	}
+}

--- a/src/adapters/llamaServerProcess.ts
+++ b/src/adapters/llamaServerProcess.ts
@@ -4,6 +4,7 @@ import {existsSync} from 'node:fs';
 export interface LlamaServerProcessOptions {
 	readonly binaryPath: string;
 	readonly modelPath: string;
+	readonly mmprojPath: string;
 	readonly host: string;
 	readonly port: number;
 	readonly contextSize: number;
@@ -39,6 +40,8 @@ export class LlamaServerProcess {
 			[
 				'-m',
 				this.options.modelPath,
+				'--mmproj',
+				this.options.mmprojPath,
 				'--host',
 				this.options.host,
 				'--port',

--- a/src/app/deps.ts
+++ b/src/app/deps.ts
@@ -2,6 +2,7 @@ import type {PersonaId} from '../domain/personas.js';
 import type {PersonaPromptData} from '../domain/prompt/buildPrompt.js';
 import type {ChatPoster} from '../ports/ChatPoster.js';
 import type {Clock} from '../ports/Clock.js';
+import type {ImageDownloader} from '../ports/ImageDownloader.js';
 import type {LlmClient} from '../ports/LlmClient.js';
 import type {Moderator} from '../ports/Moderator.js';
 import type {Publisher} from '../ports/Publisher.js';
@@ -13,6 +14,7 @@ import type {Thermometer} from '../ports/Thermometer.js';
 export interface AppDependencies {
 	readonly llm: LlmClient;
 	readonly chatPoster: ChatPoster;
+	readonly imageDownloader: ImageDownloader;
 	readonly moderator: Moderator;
 	readonly responseLog: ResponseLog;
 	readonly publisher: Publisher;
@@ -24,4 +26,6 @@ export interface AppDependencies {
 	readonly sandboxChannel: string;
 	/** Echoed back verbatim in rinna-pong replies; mirrors sys.argv[1] ('CPU'/'GPU') from worker.py. */
 	readonly mode: string;
+	/** Cap on how many recent Slack image attachments to send per generation. */
+	readonly maxRecentImages: number;
 }

--- a/src/app/generatePersonaResponse.ts
+++ b/src/app/generatePersonaResponse.ts
@@ -1,6 +1,7 @@
 import type {HumanMessage} from '../contracts/pubsubPayloads.js';
 import {type PersonaId, personaMeta} from '../domain/personas.js';
 import {buildPrompt} from '../domain/prompt/buildPrompt.js';
+import {IMAGE_MEDIA_MARKER} from '../domain/prompt/imageAttachments.js';
 import {SENTENCE_DELIMITERS} from '../domain/sentenceDelimiters.js';
 import {joinChunksToSpeech} from '../domain/speech/normalizeChunk.js';
 import {streamSpeechChunks} from '../domain/speech/streamParser.js';
@@ -72,8 +73,11 @@ export async function generateAndPostPersonaResponse(
 	character: PersonaId,
 	threadTs: string | undefined,
 	deps: AppDependencies,
+	images: readonly string[] = [],
 ): Promise<string> {
 	const personaData = deps.personaData[character];
+	const extraSuffix =
+		images.length > 0 ? IMAGE_MEDIA_MARKER.repeat(images.length) : '';
 	const {tokenIds, textInput, formattedDialog} = await buildPrompt(
 		messages,
 		character,
@@ -81,6 +85,7 @@ export async function generateAndPostPersonaResponse(
 		deps.usernameMapping,
 		(text) => deps.llm.tokenize(text),
 		deps.clock.now(),
+		extraSuffix,
 	);
 
 	if (tokenIds === null) return '';
@@ -96,8 +101,11 @@ export async function generateAndPostPersonaResponse(
 	const allChunks: string[] = [];
 	let firstChunk = true;
 
+	const generateInput =
+		images.length > 0 ? {promptText: textInput, images} : {tokenIds};
+
 	for await (const chunk of streamSpeechChunks(
-		deps.llm.streamGenerate(tokenIds),
+		deps.llm.streamGenerate(generateInput),
 		character,
 	)) {
 		if (chunk.length === 0) continue;

--- a/src/app/handlers/meaningHandler.ts
+++ b/src/app/handlers/meaningHandler.ts
@@ -48,7 +48,7 @@ export async function meaningHandler(
 	const textInput = `${meaningIntro}\n${inquiryMessage}\n${responseMessage}`;
 
 	const tokenIds = await deps.llm.tokenize(textInput);
-	const {output} = await deps.llm.generate(tokenIds);
+	const {output} = await deps.llm.generate({tokenIds});
 
 	const rawSpeech = output.split('」')[0] ?? '';
 	const rinnaSpeech = applyRinnaReplacements(rawSpeech, character);

--- a/src/app/handlers/signalHandler.ts
+++ b/src/app/handlers/signalHandler.ts
@@ -8,6 +8,7 @@ import {
 } from '../../domain/dispatch/detectPersonas.js';
 import {trimHistory} from '../../domain/dispatch/trimHistory.js';
 import {personaMeta, RINNA_BOT_ID} from '../../domain/personas.js';
+import {selectRecentImageUrls} from '../../domain/prompt/imageAttachments.js';
 import {getTopHumanUsernames} from '../../domain/prompt/topHumanUsernames.js';
 import type {AppDependencies} from '../deps.js';
 import {generateAndPostPersonaResponse} from '../generatePersonaResponse.js';
@@ -51,6 +52,14 @@ export async function signalHandler(
 		return;
 	}
 
+	const imageUrls = selectRecentImageUrls(
+		trimmedMessages,
+		deps.maxRecentImages,
+	);
+	const images = await Promise.all(
+		imageUrls.map((url) => deps.imageDownloader.downloadBase64(url)),
+	);
+
 	let messages: readonly HumanMessage[] = trimmedMessages;
 	const triggeredPersonas = detectTriggeredPersonas(triggerText);
 
@@ -61,6 +70,7 @@ export async function signalHandler(
 				persona,
 				threadTs,
 				deps,
+				images,
 			);
 			messages = [
 				...messages,
@@ -76,6 +86,12 @@ export async function signalHandler(
 		}
 	} else {
 		const fallback = pickFallbackPersona(triggerText, deps.random);
-		await generateAndPostPersonaResponse(messages, fallback, threadTs, deps);
+		await generateAndPostPersonaResponse(
+			messages,
+			fallback,
+			threadTs,
+			deps,
+			images,
+		);
 	}
 }

--- a/src/composeRoot.ts
+++ b/src/composeRoot.ts
@@ -10,6 +10,7 @@ import {ParallelModerator} from './adapters/ParallelModerator.js';
 import {PubSubClient} from './adapters/PubSubClient.js';
 import {RocmSmiThermometer} from './adapters/RocmSmiThermometer.js';
 import {SlackChatPoster} from './adapters/SlackChatPoster.js';
+import {SlackImageDownloader} from './adapters/SlackImageDownloader.js';
 import type {AppDependencies} from './app/deps.js';
 import {createRouter} from './app/router.js';
 import type {Env} from './config/env.js';
@@ -41,10 +42,15 @@ export async function composeApp(env: Env): Promise<ComposedApp> {
 		{repo: env.MODEL_REPO, file: env.MODEL_FILE},
 		env.HUGGINGFACE_TOKEN,
 	);
+	const mmprojPath = await downloadModel(
+		{repo: env.MODEL_REPO, file: env.MMPROJ_FILE},
+		env.HUGGINGFACE_TOKEN,
+	);
 
 	const llamaServerProcess = new LlamaServerProcess({
 		binaryPath: env.LLAMA_SERVER_BINARY,
 		modelPath,
+		mmprojPath,
 		host: env.LLAMA_SERVER_HOST,
 		port: env.LLAMA_SERVER_PORT,
 		contextSize: env.LLAMA_CONTEXT_SIZE,
@@ -64,6 +70,7 @@ export async function composeApp(env: Env): Promise<ComposedApp> {
 	const firestore = getFirestore();
 
 	const chatPoster = new SlackChatPoster(env.SLACK_TOKEN);
+	const imageDownloader = new SlackImageDownloader(env.SLACK_TOKEN);
 	const moderator = new ParallelModerator(
 		new GoogleLanguageModerator(),
 		new AzureContentModerator({
@@ -81,6 +88,7 @@ export async function composeApp(env: Env): Promise<ComposedApp> {
 	const deps: AppDependencies = {
 		llm,
 		chatPoster,
+		imageDownloader,
 		moderator,
 		responseLog,
 		publisher: pubsub,
@@ -91,6 +99,7 @@ export async function composeApp(env: Env): Promise<ComposedApp> {
 		usernameMapping,
 		sandboxChannel: env.SANDBOX_CHANNEL_ID,
 		mode: env.LLAMA_GPU ? 'GPU' : 'CPU',
+		maxRecentImages: env.MAX_RECENT_IMAGES,
 	};
 
 	const route = createRouter(deps);

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -27,6 +27,8 @@ const envSchema = z.object({
 
 	MODEL_REPO: z.string().default('mradermacher/Qwen3.5-35B-A3B-Base-GGUF'),
 	MODEL_FILE: z.string().default('Qwen3.5-35B-A3B-Base.Q6_K.gguf'),
+	MMPROJ_FILE: z.string().default('Qwen3.5-35B-A3B-Base.mmproj-Q8_0.gguf'),
+	MAX_RECENT_IMAGES: z.coerce.number().int().default(3),
 
 	DATA_DIR: z.string().default('data'),
 });

--- a/src/contracts/pubsubPayloads.ts
+++ b/src/contracts/pubsubPayloads.ts
@@ -6,6 +6,13 @@ import {z} from 'zod';
  * Only the fields worker.py's rinna-signal flow actually reads are required;
  * everything else is optional since Slack payloads carry many unused fields.
  */
+export const slackFileSchema = z.object({
+	url_private: z.string(),
+	mimetype: z.string(),
+});
+
+export type SlackFile = z.infer<typeof slackFileSchema>;
+
 export const humanMessageSchema = z.object({
 	text: z.string().nullable().optional(),
 	ts: z.string(),
@@ -14,6 +21,7 @@ export const humanMessageSchema = z.object({
 	bot_id: z.string().optional(),
 	subtype: z.string().optional(),
 	thread_ts: z.string().optional(),
+	files: z.array(slackFileSchema).optional(),
 });
 
 export type HumanMessage = z.infer<typeof humanMessageSchema>;

--- a/src/domain/prompt/buildPrompt.ts
+++ b/src/domain/prompt/buildPrompt.ts
@@ -103,6 +103,9 @@ export async function buildPrompt(
 	usernameMapping: Record<string, string>,
 	tokenize: Tokenize,
 	now: Date,
+	/** Appended right before the persona's speech-opening 「, e.g. image
+	 * markers for attached images. Opaque to buildPrompt itself. */
+	extraSuffix = '',
 ): Promise<BuildPromptResult> {
 	const meta = personaMeta[character];
 	const lastMessage = messages.at(-1);
@@ -119,7 +122,7 @@ export async function buildPrompt(
 			user2,
 		);
 		const formattedDialog = `質問「${lastMessageText}」`;
-		const textInput = `${inquiryIntro}\n${formattedDialog}\n回答「`;
+		const textInput = `${inquiryIntro}\n${formattedDialog}${extraSuffix}\n回答「`;
 		const tokenIds = await tokenize(textInput);
 		return {tokenIds, textInput, formattedDialog};
 	}
@@ -143,7 +146,7 @@ export async function buildPrompt(
 		window.unshift(message);
 		formattedDialog = window.map(formatMessage).join('\n');
 		const candidateText = substituteDatePlaceholders(
-			`${intro}\n${formattedDialog}${outro}`,
+			`${intro}\n${formattedDialog}${extraSuffix}${outro}`,
 			now,
 		);
 

--- a/src/domain/prompt/imageAttachments.ts
+++ b/src/domain/prompt/imageAttachments.ts
@@ -1,0 +1,48 @@
+import type {HumanMessage, SlackFile} from '../../contracts/pubsubPayloads.js';
+
+/** llama.cpp's mtmd_default_marker(); prompt_string markers are substituted
+ * positionally with multimodal_data entries, so this must match the
+ * llama-server build exactly. */
+export const IMAGE_MEDIA_MARKER = '<__media__>';
+
+export function selectImageFiles(
+	files: readonly SlackFile[] | undefined,
+): readonly SlackFile[] {
+	if (files === undefined) return [];
+	return files.filter((file) => file.mimetype.startsWith('image/'));
+}
+
+/**
+ * Scans all messages for image attachments and keeps only the most recent
+ * maxImages across the whole window, returned in chronological order
+ * (oldest kept image first).
+ *
+ * Note: normalizeText (used when formatting dialogue text in buildPrompt)
+ * strips any `<...>` tag from message text, so image markers can't be
+ * embedded into a message's own text — buildPrompt's extraSuffix parameter
+ * is used instead to attach IMAGE_MEDIA_MARKER.repeat(urls.length) once, at
+ * the end of the prompt.
+ */
+export function selectRecentImageUrls(
+	messages: readonly HumanMessage[],
+	maxImages: number,
+): readonly string[] {
+	interface Entry {
+		readonly url: string;
+		readonly ts: number;
+	}
+
+	const entries: Entry[] = [];
+	for (const message of messages) {
+		for (const file of selectImageFiles(message.files)) {
+			entries.push({url: file.url_private, ts: Number.parseFloat(message.ts)});
+		}
+	}
+
+	return entries
+		.slice()
+		.sort((a, b) => b.ts - a.ts)
+		.slice(0, maxImages)
+		.sort((a, b) => a.ts - b.ts)
+		.map((entry) => entry.url);
+}

--- a/src/ports/ImageDownloader.ts
+++ b/src/ports/ImageDownloader.ts
@@ -1,0 +1,5 @@
+export interface ImageDownloader {
+	/** Downloads an authenticated image URL (e.g. Slack's url_private) and
+	 * returns its bytes as a base64-encoded string. */
+	downloadBase64(url: string): Promise<string>;
+}

--- a/src/ports/LlmClient.ts
+++ b/src/ports/LlmClient.ts
@@ -3,16 +3,23 @@ export interface GenerationConfig {
 	readonly modelName: string;
 }
 
+/** Either a pre-tokenized text-only prompt, or a raw prompt string paired
+ * with base64-encoded images (llama-server's multimodal /completion path,
+ * which requires an untokenized prompt_string). */
+export type GenerateInput =
+	| {readonly tokenIds: readonly number[]}
+	| {readonly promptText: string; readonly images: readonly string[]};
+
 export interface LlmClient {
 	/** Static provider/model identity, for logging generations that don't go through generate(). */
 	describe(): GenerationConfig;
 	tokenize(text: string): Promise<readonly number[]>;
 	/** Non-streaming generation, stopping at the outer speech's closing 」. Used by the meaning flow. */
 	generate(
-		tokenIds: readonly number[],
+		input: GenerateInput,
 	): Promise<{output: string; config: GenerationConfig}>;
 	/** Streaming generation. Yields raw text pieces and stops once the outer
 	 * speech's closing 」 is detected (tracking 「/」 nesting depth so a quoted
 	 * word inside the speech doesn't end generation early). */
-	streamGenerate(tokenIds: readonly number[]): AsyncIterable<string>;
+	streamGenerate(input: GenerateInput): AsyncIterable<string>;
 }

--- a/tests/adapters/LlamaServerClient.test.ts
+++ b/tests/adapters/LlamaServerClient.test.ts
@@ -46,7 +46,7 @@ describe('LlamaServerClient.streamGenerate', () => {
 			modelFile: 'f',
 		});
 		const chunks: string[] = [];
-		for await (const piece of client.streamGenerate([1, 2, 3])) {
+		for await (const piece of client.streamGenerate({tokenIds: [1, 2, 3]})) {
 			chunks.push(piece);
 		}
 		expect(chunks.join('')).toBe('おはよう');
@@ -68,7 +68,7 @@ describe('LlamaServerClient.streamGenerate', () => {
 			modelFile: 'f',
 		});
 		const chunks: string[] = [];
-		for await (const piece of client.streamGenerate([1])) {
+		for await (const piece of client.streamGenerate({tokenIds: [1]})) {
 			chunks.push(piece);
 		}
 		expect(chunks.join('')).toBe('おはよう');
@@ -90,7 +90,7 @@ describe('LlamaServerClient.streamGenerate', () => {
 			modelFile: 'f',
 		});
 		const chunks: string[] = [];
-		for await (const piece of client.streamGenerate([1])) {
+		for await (const piece of client.streamGenerate({tokenIds: [1]})) {
 			chunks.push(piece);
 		}
 		// The nested 「入れ子」 pair doesn't trigger the stop; only the final
@@ -112,7 +112,7 @@ describe('LlamaServerClient.streamGenerate', () => {
 			modelName: 'm',
 			modelFile: 'f',
 		});
-		for await (const _piece of client.streamGenerate([7, 8, 9])) {
+		for await (const _piece of client.streamGenerate({tokenIds: [7, 8, 9]})) {
 			// drain
 		}
 
@@ -124,6 +124,35 @@ describe('LlamaServerClient.streamGenerate', () => {
 		expect(parsed.prompt).toEqual([7, 8, 9]);
 		expect(parsed.stream).toBe(true);
 		expect(parsed.temperature).toBe(0.6);
+	});
+
+	it('sends a prompt_string/multimodal_data object when images are attached', async () => {
+		let capturedBody = '';
+		const served = await serveOnce((_path, body) => {
+			capturedBody = body;
+			return {status: 200, body: sseBody([{content: 'ok', stop: true}])};
+		});
+		server = served.server;
+
+		const client = new LlamaServerClient({
+			baseUrl: served.baseUrl,
+			modelName: 'm',
+			modelFile: 'f',
+		});
+		for await (const _piece of client.streamGenerate({
+			promptText: '質問「これは何？」<__media__>',
+			images: ['base64data'],
+		})) {
+			// drain
+		}
+
+		const parsed = JSON.parse(capturedBody) as {
+			prompt: {prompt_string: string; multimodal_data: string[]};
+		};
+		expect(parsed.prompt).toEqual({
+			prompt_string: '質問「これは何？」<__media__>',
+			multimodal_data: ['base64data'],
+		});
 	});
 });
 
@@ -167,7 +196,7 @@ describe('LlamaServerClient.generate', () => {
 			modelName: 'my-model',
 			modelFile: 'f.gguf',
 		});
-		const result = await client.generate([1, 2]);
+		const result = await client.generate({tokenIds: [1, 2]});
 		expect(result.output).toBe('おはよう」');
 		expect(result.config).toEqual({
 			modelProvider: 'llama-server',
@@ -187,6 +216,8 @@ describe('LlamaServerClient.generate', () => {
 			modelName: 'm',
 			modelFile: 'f',
 		});
-		await expect(client.generate([1])).rejects.toThrow('output_text is empty');
+		await expect(client.generate({tokenIds: [1]})).rejects.toThrow(
+			'output_text is empty',
+		);
 	});
 });

--- a/tests/adapters/SlackImageDownloader.test.ts
+++ b/tests/adapters/SlackImageDownloader.test.ts
@@ -1,0 +1,103 @@
+import {createServer, type Server} from 'node:http';
+import sharp from 'sharp';
+import {afterEach, describe, expect, it} from 'vitest';
+import {SlackImageDownloader} from '../../src/adapters/SlackImageDownloader.js';
+
+function makePng(width: number, height: number): Promise<Buffer> {
+	return sharp({
+		create: {
+			width,
+			height,
+			channels: 3,
+			background: {r: 200, g: 100, b: 50},
+		},
+	})
+		.png()
+		.toBuffer();
+}
+
+async function serveOnce(
+	handler: (headers: Record<string, string | string[] | undefined>) => {
+		status: number;
+		body: Buffer;
+	},
+) {
+	const server: Server = createServer((req, res) => {
+		const {status, body} = handler(req.headers);
+		res.writeHead(status);
+		res.end(body);
+	});
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const address = server.address();
+	if (address === null || typeof address === 'string')
+		throw new Error('unexpected address');
+	return {server, baseUrl: `http://127.0.0.1:${address.port}`};
+}
+
+describe('SlackImageDownloader', () => {
+	let server: Server;
+
+	afterEach(() => {
+		server.close();
+	});
+
+	it('sends the token as a Bearer Authorization header and returns a decodable base64 image', async () => {
+		let capturedAuth: string | undefined;
+		const png = await makePng(100, 80);
+		const served = await serveOnce((headers) => {
+			capturedAuth = headers.authorization as string | undefined;
+			return {status: 200, body: png};
+		});
+		server = served.server;
+
+		const downloader = new SlackImageDownloader('xoxb-test-token');
+		const result = await downloader.downloadBase64(`${served.baseUrl}/img.png`);
+
+		expect(capturedAuth).toBe('Bearer xoxb-test-token');
+		const metadata = await sharp(Buffer.from(result, 'base64')).metadata();
+		expect(metadata.format).toBe('jpeg');
+		expect(metadata.width).toBe(100);
+		expect(metadata.height).toBe(80);
+	});
+
+	it('downscales images larger than the max dimension without upscaling smaller ones', async () => {
+		const large = await makePng(3000, 1500);
+		const served = await serveOnce(() => ({status: 200, body: large}));
+		server = served.server;
+
+		const downloader = new SlackImageDownloader('xoxb-test-token');
+		const result = await downloader.downloadBase64(`${served.baseUrl}/big.png`);
+
+		const metadata = await sharp(Buffer.from(result, 'base64')).metadata();
+		expect(metadata.width).toBeLessThanOrEqual(2048);
+		expect(metadata.height).toBeLessThanOrEqual(2048);
+		// aspect ratio preserved (2:1)
+		expect(metadata.width).toBe((metadata.height ?? 0) * 2);
+	});
+
+	it('throws when the download fails', async () => {
+		const served = await serveOnce(() => ({
+			status: 404,
+			body: Buffer.from('not found'),
+		}));
+		server = served.server;
+
+		const downloader = new SlackImageDownloader('xoxb-test-token');
+		await expect(
+			downloader.downloadBase64(`${served.baseUrl}/missing.png`),
+		).rejects.toThrow('404');
+	});
+
+	it('throws a clear error when the downloaded bytes are not a valid image', async () => {
+		const served = await serveOnce(() => ({
+			status: 200,
+			body: Buffer.from('not an image'),
+		}));
+		server = served.server;
+
+		const downloader = new SlackImageDownloader('xoxb-test-token');
+		await expect(
+			downloader.downloadBase64(`${served.baseUrl}/broken.png`),
+		).rejects.toThrow('Failed to normalize downloaded image');
+	});
+});

--- a/tests/app/fakeDeps.ts
+++ b/tests/app/fakeDeps.ts
@@ -6,7 +6,12 @@ import type {
 	PostMessageParams,
 } from '../../src/ports/ChatPoster.js';
 import type {Clock} from '../../src/ports/Clock.js';
-import type {GenerationConfig, LlmClient} from '../../src/ports/LlmClient.js';
+import type {ImageDownloader} from '../../src/ports/ImageDownloader.js';
+import type {
+	GenerateInput,
+	GenerationConfig,
+	LlmClient,
+} from '../../src/ports/LlmClient.js';
 import type {ModerationResult, Moderator} from '../../src/ports/Moderator.js';
 import type {Publisher} from '../../src/ports/Publisher.js';
 import type {RandomSource} from '../../src/ports/Random.js';
@@ -16,6 +21,7 @@ import type {Thermometer} from '../../src/ports/Thermometer.js';
 export class FakeLlmClient implements LlmClient {
 	streamPieces: string[] = [];
 	generateOutput = 'ダミー」';
+	receivedInputs: GenerateInput[] = [];
 
 	describe(): GenerationConfig {
 		return {modelProvider: 'fake', modelName: 'fake-model'};
@@ -26,17 +32,28 @@ export class FakeLlmClient implements LlmClient {
 	}
 
 	async generate(
-		_tokenIds: readonly number[],
+		input: GenerateInput,
 	): Promise<{output: string; config: GenerationConfig}> {
+		this.receivedInputs.push(input);
 		return {output: this.generateOutput, config: this.describe()};
 	}
 
 	async *streamGenerate(
-		_tokenIds: readonly number[],
+		input: GenerateInput,
 	): AsyncGenerator<string, void, undefined> {
+		this.receivedInputs.push(input);
 		for (const piece of this.streamPieces) {
 			yield piece;
 		}
+	}
+}
+
+export class FakeImageDownloader implements ImageDownloader {
+	downloadedUrls: string[] = [];
+
+	async downloadBase64(url: string): Promise<string> {
+		this.downloadedUrls.push(url);
+		return `base64(${url})`;
 	}
 }
 
@@ -105,6 +122,7 @@ export function fakePersonaData(): Record<PersonaId, PersonaPromptData> {
 export interface FakeDeps {
 	llm: FakeLlmClient;
 	chatPoster: FakeChatPoster;
+	imageDownloader: FakeImageDownloader;
 	moderator: FakeModerator;
 	responseLog: FakeResponseLog;
 	publisher: FakePublisher;
@@ -117,6 +135,7 @@ export function createFakeDeps(
 ): FakeDeps {
 	const llm = new FakeLlmClient();
 	const chatPoster = new FakeChatPoster();
+	const imageDownloader = new FakeImageDownloader();
 	const moderator = new FakeModerator();
 	const responseLog = new FakeResponseLog();
 	const publisher = new FakePublisher();
@@ -125,6 +144,7 @@ export function createFakeDeps(
 	const deps: AppDependencies = {
 		llm,
 		chatPoster,
+		imageDownloader,
 		moderator,
 		responseLog,
 		publisher,
@@ -135,11 +155,13 @@ export function createFakeDeps(
 		usernameMapping: {U1: '博多市', U2: 'ひでお'},
 		sandboxChannel: 'C_TEST',
 		mode: 'CPU',
+		maxRecentImages: 3,
 	};
 
 	return {
 		llm,
 		chatPoster,
+		imageDownloader,
 		moderator,
 		responseLog,
 		publisher,

--- a/tests/app/generatePersonaResponse.test.ts
+++ b/tests/app/generatePersonaResponse.test.ts
@@ -119,4 +119,43 @@ describe('generateAndPostPersonaResponse', () => {
 		expect(result).toBe('');
 		expect(chatPoster.posts).toHaveLength(0);
 	});
+
+	it('generates with promptText+images when images are provided, appending an image marker per image', async () => {
+		const {llm, deps} = createFakeDeps();
+		llm.streamPieces = ['はーい。'];
+
+		const promise = generateAndPostPersonaResponse(
+			messages,
+			'りんな',
+			undefined,
+			deps,
+			['base64img'],
+		);
+		await vi.runAllTimersAsync();
+		await promise;
+
+		const input = llm.receivedInputs[0];
+		expect(input && 'promptText' in input).toBe(true);
+		if (input && 'promptText' in input) {
+			expect(input.images).toEqual(['base64img']);
+			expect(input.promptText).toContain('<__media__>');
+		}
+	});
+
+	it('uses the tokenIds path when no images are provided', async () => {
+		const {llm, deps} = createFakeDeps();
+		llm.streamPieces = ['はーい。'];
+
+		const promise = generateAndPostPersonaResponse(
+			messages,
+			'りんな',
+			undefined,
+			deps,
+		);
+		await vi.runAllTimersAsync();
+		await promise;
+
+		const input = llm.receivedInputs[0];
+		expect(input && 'tokenIds' in input).toBe(true);
+	});
 });

--- a/tests/app/handlers/signalHandler.test.ts
+++ b/tests/app/handlers/signalHandler.test.ts
@@ -179,4 +179,102 @@ describe('signalHandler', () => {
 		await signalHandler(signal([]), deps);
 		expect(chatPoster.posts).toHaveLength(0);
 	});
+
+	it('downloads an attached image and generates with promptText+images', async () => {
+		const {llm, imageDownloader, deps} = createFakeDeps(NOW);
+		llm.streamPieces = ['はーい。'];
+
+		const promise = signalHandler(
+			signal([
+				{
+					text: 'りんな、これ見て',
+					user: 'U1',
+					ts: String(NOW.getTime() / 1000),
+					files: [
+						{url_private: 'https://slack/img.png', mimetype: 'image/png'},
+					],
+				},
+			]),
+			deps,
+		);
+		await vi.runAllTimersAsync();
+		await promise;
+
+		expect(imageDownloader.downloadedUrls).toEqual(['https://slack/img.png']);
+		const input = llm.receivedInputs[0];
+		expect(input && 'promptText' in input).toBe(true);
+		if (input && 'promptText' in input) {
+			expect(input.images).toEqual(['base64(https://slack/img.png)']);
+			expect(input.promptText).toContain('<__media__>');
+		}
+	});
+
+	it('ignores non-image attachments', async () => {
+		const {llm, imageDownloader, deps} = createFakeDeps(NOW);
+		llm.streamPieces = ['はーい。'];
+
+		const promise = signalHandler(
+			signal([
+				{
+					text: 'りんな、これ見て',
+					user: 'U1',
+					ts: String(NOW.getTime() / 1000),
+					files: [
+						{url_private: 'https://slack/doc.pdf', mimetype: 'application/pdf'},
+					],
+				},
+			]),
+			deps,
+		);
+		await vi.runAllTimersAsync();
+		await promise;
+
+		expect(imageDownloader.downloadedUrls).toHaveLength(0);
+		const input = llm.receivedInputs[0];
+		expect(input && 'tokenIds' in input).toBe(true);
+	});
+
+	it('keeps only the 3 most recent images across the history window', async () => {
+		const {imageDownloader, llm, deps} = createFakeDeps(NOW);
+		llm.streamPieces = ['はーい。'];
+		const baseTs = NOW.getTime() / 1000;
+
+		const promise = signalHandler(
+			signal([
+				{
+					text: '1枚目',
+					user: 'U1',
+					ts: String(baseTs - 30),
+					files: [{url_private: 'https://slack/1.png', mimetype: 'image/png'}],
+				},
+				{
+					text: '2枚目',
+					user: 'U1',
+					ts: String(baseTs - 20),
+					files: [{url_private: 'https://slack/2.png', mimetype: 'image/png'}],
+				},
+				{
+					text: '3枚目',
+					user: 'U1',
+					ts: String(baseTs - 10),
+					files: [{url_private: 'https://slack/3.png', mimetype: 'image/png'}],
+				},
+				{
+					text: 'りんな、4枚目',
+					user: 'U1',
+					ts: String(baseTs),
+					files: [{url_private: 'https://slack/4.png', mimetype: 'image/png'}],
+				},
+			]),
+			deps,
+		);
+		await vi.runAllTimersAsync();
+		await promise;
+
+		expect(imageDownloader.downloadedUrls).toEqual([
+			'https://slack/2.png',
+			'https://slack/3.png',
+			'https://slack/4.png',
+		]);
+	});
 });

--- a/tests/domain/imageAttachments.test.ts
+++ b/tests/domain/imageAttachments.test.ts
@@ -1,0 +1,80 @@
+import {describe, expect, it} from 'vitest';
+import type {HumanMessage} from '../../src/contracts/pubsubPayloads.js';
+import {
+	selectImageFiles,
+	selectRecentImageUrls,
+} from '../../src/domain/prompt/imageAttachments.js';
+
+function msg(
+	text: string,
+	ts: string,
+	files?: HumanMessage['files'],
+): HumanMessage {
+	return {text, ts, files};
+}
+
+describe('selectImageFiles', () => {
+	it('keeps only image/* mimetypes', () => {
+		const files = [
+			{url_private: 'a', mimetype: 'image/png'},
+			{url_private: 'b', mimetype: 'application/pdf'},
+			{url_private: 'c', mimetype: 'image/jpeg'},
+		];
+		expect(selectImageFiles(files)).toEqual([
+			{url_private: 'a', mimetype: 'image/png'},
+			{url_private: 'c', mimetype: 'image/jpeg'},
+		]);
+	});
+
+	it('returns an empty array when files is undefined', () => {
+		expect(selectImageFiles(undefined)).toEqual([]);
+	});
+});
+
+describe('selectRecentImageUrls', () => {
+	it('returns an empty array when nothing has image attachments', () => {
+		const messages = [msg('hello', '1')];
+		expect(selectRecentImageUrls(messages, 3)).toEqual([]);
+	});
+
+	it('collects image urls from messages that carry them', () => {
+		const messages = [
+			msg('no image', '1'),
+			msg('with image', '2', [{url_private: 'img1', mimetype: 'image/png'}]),
+		];
+		expect(selectRecentImageUrls(messages, 3)).toEqual(['img1']);
+	});
+
+	it('ignores non-image attachments', () => {
+		const messages = [
+			msg('a doc', '1', [{url_private: 'doc', mimetype: 'application/pdf'}]),
+		];
+		expect(selectRecentImageUrls(messages, 3)).toEqual([]);
+	});
+
+	it('caps at maxImages, keeping the newest ones in chronological order', () => {
+		const messages = [
+			msg('1', '10', [{url_private: 'img1', mimetype: 'image/png'}]),
+			msg('2', '20', [{url_private: 'img2', mimetype: 'image/png'}]),
+			msg('3', '30', [{url_private: 'img3', mimetype: 'image/png'}]),
+			msg('4', '40', [{url_private: 'img4', mimetype: 'image/png'}]),
+		];
+		// img1 (ts=10) is dropped as the oldest; survivors are returned oldest
+		// first among themselves, matching the order they'll be attached in.
+		expect(selectRecentImageUrls(messages, 3)).toEqual([
+			'img2',
+			'img3',
+			'img4',
+		]);
+	});
+
+	it('collects multiple images from a single message', () => {
+		const messages = [
+			msg('multi', '1', [
+				{url_private: 'a', mimetype: 'image/png'},
+				{url_private: 'b', mimetype: 'image/jpeg'},
+			]),
+		];
+		expect(selectRecentImageUrls(messages, 3)).toEqual(['a', 'b']);
+	});
+});


### PR DESCRIPTION
## Summary
- Slack image attachments (already present in the `rinna-signal` Pub/Sub payload's raw `files` field, previously discarded by `humanMessageSchema`) are now downloaded and passed to the persona LLM as vision input.
- `signalHandler` collects up to `MAX_RECENT_IMAGES` (env-configurable, default 3) most recent images across the 15-minute history window per signal, once, so every persona mentioned in the same message sees the same images.
- New `SlackImageDownloader` adapter authenticates with `SLACK_TOKEN` to fetch `url_private`, then normalizes each image with `sharp` (EXIF auto-rotate, downscale to fit llama.cpp mtmd's `image_max_pixels` limit, re-encode as JPEG) — this also sidesteps format edge cases (CMYK JPEGs, animated GIFs, etc.) that caused intermittent `"failed to process image"` 500s from llama-server.
- `LlmClient.generate`/`streamGenerate` now take a `GenerateInput` union (`{tokenIds}` for the existing text-only path, or `{promptText, images}` for llama-server's multimodal `/completion` shape); `LlamaServerClient` branches the request body accordingly.
- `llamaServerProcess.ts` now always starts `llama-server` with `--mmproj` (downloaded from the same `MODEL_REPO`), so vision is loaded unconditionally.
- `buildPrompt` gained an `extraSuffix` param (image markers are appended there, not into a message's own text — `normalizeText` strips any `<...>` tag, so markers can't survive being embedded per-message).
- `CLAUDE.md` updated to document the new architecture pieces and non-obvious gotchas (marker stripping, mmproj VRAM cost, multimodal request shape).

## Test plan
- [x] `npm run typecheck && npm test` (115 tests, all green)
- [x] `npm run lint` (clean on all touched files)
- [x] Live VRAM check on the MI50: mmproj-loaded idle ~30.5GB/34.3GB, peak with 3 simultaneous images ~30.75GB/34.3GB — safe margin
- [x] Live Slack verification by the repo owner: image-attached messages now generate correctly with no `"failed to process image"` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3u4W1LQyY5mYxYAM8jiT8