### PR TITLE
Fix stale-cache and inquiry-mode image bugs found in live testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,16 @@ implementations:
   `{promptText, images}` (base64 strings) for llama-server's multimodal `/completion` shape
   (`prompt: {prompt_string, multimodal_data}` — the current llama.cpp server API, not the older
   `image_data` field some docs still reference). Marker count in `prompt_string` and
-  `multimodal_data.length` must match exactly or the server 500s.
+  `multimodal_data.length` must match exactly or the server 500s. `llamaServerProcess.ts` also
+  passes `--parallel 1 --no-cache-prompt --cache-ram 0`: `mutex.ts` already serializes all
+  generation to one request at a time so extra slots only waste VRAM, and llama-server's
+  cross-request prompt/KV-cache reuse (both the classic per-slot prefix cache and the newer
+  `--cache-ram` checkpoint cache from
+  [PR #16391](https://github.com/ggml-org/llama.cpp/pull/16391)) is the leading suspect for
+  intermittent `"failed to process image"` 500s that only start appearing after a slot has
+  already processed one multimodal prompt — not conclusively confirmed (couldn't reproduce it
+  directly), but disabling it costs nothing since buildPrompt always sends a fresh full prompt
+  anyway.
 - `modelDownloader.ts` — pulls the GGUF (and the mmproj file) from Hugging Face Hub via
   `@huggingface/hub`.
 - `SlackImageDownloader` — downloads a Slack `url_private` with `Authorization: Bearer
@@ -139,10 +148,15 @@ implementations:
   `/clear`/`/no_clear`, then either the `@うな先生` meaning flow or firing each mentioned persona
   in turn (each one's reply is appended to the running history before the next persona generates,
   so multiple personas mentioned in one message "see" each other's replies). Also selects and
-  downloads (via `ImageDownloader`) the most recent `maxRecentImages` Slack images from the
-  window once per signal, before the persona loop, so every persona mentioned by the same message
-  sees the same images (the `@うな先生` meaning flow doesn't get images — `rinna-meaning`'s payload
-  carries only `{word, ts}`, no message history).
+  downloads (via `ImageDownloader`) the most recent `maxRecentImages` Slack images once per signal,
+  before the persona loop, so every persona mentioned by the same message sees the same images
+  (the `@うな先生` meaning flow doesn't get images — `rinna-meaning`'s payload carries only
+  `{word, ts}`, no message history). Image *source* scope depends on `isInquiryText(triggerText)`
+  (re-exported from `buildPrompt.ts`): a plain-text trigger scans the whole trimmed window (up to
+  `maxRecentImages`, newest first), but an inquiry-mode trigger ("うな、○○？") scans only the
+  trigger message itself — this mirrors buildPrompt's own isInquiry branch, which likewise ignores
+  all history and answers from the trigger message alone, so an unrelated image posted earlier in
+  the 15-minute window must not leak into an inquiry answer that isn't about it.
 - `handlers/meaningHandler.ts` — the `@うな先生` / `rinna-meaning` flow. Always sleeps 1s before
   posting every chunk, including the first (unlike the persona-response flow, which skips the
   sleep before its first chunk).

--- a/src/adapters/llamaServerProcess.ts
+++ b/src/adapters/llamaServerProcess.ts
@@ -50,6 +50,19 @@ export class LlamaServerProcess {
 				String(this.options.contextSize),
 				'-ngl',
 				this.options.gpuMode ? '-1' : '0',
+				// mutex.ts already serializes all generation to one request at a
+				// time, so extra parallel slots only waste VRAM. More importantly,
+				// llama-server's cross-request KV/prompt-reuse caching (both the
+				// classic per-slot prefix cache and the newer --cache-ram
+				// checkpoint cache) is a suspected cause of intermittent
+				// "failed to process image" 500s once a slot has processed a
+				// multimodal prompt — we never need reuse since buildPrompt always
+				// sends a fresh full prompt, so it's disabled outright.
+				'--parallel',
+				'1',
+				'--no-cache-prompt',
+				'--cache-ram',
+				'0',
 			],
 			{detached: true, stdio: ['ignore', 'pipe', 'pipe']},
 		);

--- a/src/app/handlers/signalHandler.ts
+++ b/src/app/handlers/signalHandler.ts
@@ -8,6 +8,7 @@ import {
 } from '../../domain/dispatch/detectPersonas.js';
 import {trimHistory} from '../../domain/dispatch/trimHistory.js';
 import {personaMeta, RINNA_BOT_ID} from '../../domain/personas.js';
+import {isInquiryText} from '../../domain/prompt/buildPrompt.js';
 import {selectRecentImageUrls} from '../../domain/prompt/imageAttachments.js';
 import {getTopHumanUsernames} from '../../domain/prompt/topHumanUsernames.js';
 import type {AppDependencies} from '../deps.js';
@@ -52,8 +53,15 @@ export async function signalHandler(
 		return;
 	}
 
+	// Inquiry-mode replies ("うな、○○？") only ever look at the trigger message
+	// itself (see buildPrompt's isInquiry branch), so image selection must be
+	// scoped the same way — otherwise an unrelated image from earlier in the
+	// 15-minute window would get attached to a plain-text question.
+	const imageSourceMessages = isInquiryText(triggerText)
+		? [triggerMessage]
+		: trimmedMessages;
 	const imageUrls = selectRecentImageUrls(
-		trimmedMessages,
+		imageSourceMessages,
 		deps.maxRecentImages,
 	);
 	const images = await Promise.all(

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -28,7 +28,7 @@ const envSchema = z.object({
 	MODEL_REPO: z.string().default('mradermacher/Qwen3.5-35B-A3B-Base-GGUF'),
 	MODEL_FILE: z.string().default('Qwen3.5-35B-A3B-Base.Q6_K.gguf'),
 	MMPROJ_FILE: z.string().default('Qwen3.5-35B-A3B-Base.mmproj-Q8_0.gguf'),
-	MAX_RECENT_IMAGES: z.coerce.number().int().default(3),
+	MAX_RECENT_IMAGES: z.coerce.number().int().default(1),
 
 	DATA_DIR: z.string().default('data'),
 });

--- a/src/domain/prompt/buildPrompt.ts
+++ b/src/domain/prompt/buildPrompt.ts
@@ -32,6 +32,14 @@ export interface BuildPromptResult {
 
 export type Tokenize = (text: string) => Promise<readonly number[]>;
 
+/** A trigger message ending in ？/? gets the "quick inquiry" prompt shape
+ * (only the trigger message itself, no history). Exported so callers that
+ * need to know this ahead of buildPrompt (e.g. deciding which messages'
+ * image attachments are even in scope) can replicate the same rule. */
+export function isInquiryText(text: string): boolean {
+	return text.endsWith('？') || text.endsWith('?');
+}
+
 function resolveSpeakerName(
 	message: HumanMessage,
 	usernameMapping: Record<string, string>,
@@ -110,8 +118,7 @@ export async function buildPrompt(
 	const meta = personaMeta[character];
 	const lastMessage = messages.at(-1);
 	const lastMessageText = lastMessage?.text ?? '';
-	const isInquiry =
-		lastMessageText.endsWith('？') || lastMessageText.endsWith('?');
+	const isInquiry = isInquiryText(lastMessageText);
 
 	const [user1, user2] = getTopHumanUsernames(messages, usernameMapping);
 

--- a/tests/app/handlers/signalHandler.test.ts
+++ b/tests/app/handlers/signalHandler.test.ts
@@ -277,4 +277,56 @@ describe('signalHandler', () => {
 			'https://slack/4.png',
 		]);
 	});
+
+	it('does not attach images from earlier history to an inquiry-mode message', async () => {
+		const {llm, imageDownloader, deps} = createFakeDeps(NOW);
+		llm.streamPieces = ['はーい。'];
+		const baseTs = NOW.getTime() / 1000;
+
+		const promise = signalHandler(
+			signal([
+				{
+					text: 'これ見て',
+					user: 'U1',
+					ts: String(baseTs - 10),
+					files: [
+						{url_private: 'https://slack/old.png', mimetype: 'image/png'},
+					],
+				},
+				{
+					text: 'りんな、これ何？',
+					user: 'U1',
+					ts: String(baseTs),
+				},
+			]),
+			deps,
+		);
+		await vi.runAllTimersAsync();
+		await promise;
+
+		expect(imageDownloader.downloadedUrls).toHaveLength(0);
+	});
+
+	it('still attaches an image that is on the inquiry trigger message itself', async () => {
+		const {llm, imageDownloader, deps} = createFakeDeps(NOW);
+		llm.streamPieces = ['はーい。'];
+
+		const promise = signalHandler(
+			signal([
+				{
+					text: 'りんな、これ何？',
+					user: 'U1',
+					ts: String(NOW.getTime() / 1000),
+					files: [
+						{url_private: 'https://slack/new.png', mimetype: 'image/png'},
+					],
+				},
+			]),
+			deps,
+		);
+		await vi.runAllTimersAsync();
+		await promise;
+
+		expect(imageDownloader.downloadedUrls).toEqual(['https://slack/new.png']);
+	});
 });


### PR DESCRIPTION
## Summary
- Disable llama-server's cross-request prompt/KV-cache reuse (`--no-cache-prompt --cache-ram 0`) and extra parallel slots (`--parallel 1`): the leading suspect for intermittent `"failed to process image"` 500s that only start after a slot has processed one multimodal prompt. `mutex.ts` already serializes generation to one request at a time, so neither feature benefits this app.
- Scope image selection to the trigger message alone when the trigger is inquiry-mode text (`うな、○○？`), matching `buildPrompt`'s own `isInquiry` branch which ignores all other history — previously an unrelated image from earlier in the 15-minute window could leak into an inquiry answer that isn't about it.
- Lower `MAX_RECENT_IMAGES` default from 3 to 1.

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`