### PR TITLE
inquiry分岐のトリガーメッセージにもnormalizeTextを適用

### DIFF
--- a/src/domain/prompt/buildPrompt.ts
+++ b/src/domain/prompt/buildPrompt.ts
@@ -128,7 +128,7 @@ export async function buildPrompt(
 			user1,
 			user2,
 		);
-		const formattedDialog = `質問「${lastMessageText}」`;
+		const formattedDialog = `質問「${normalizeText(lastMessageText)}」`;
 		const textInput = `${inquiryIntro}\n${formattedDialog}${extraSuffix}\n回答「`;
 		const tokenIds = await tokenize(textInput);
 		return {tokenIds, textInput, formattedDialog};

--- a/tests/domain/buildPrompt.test.ts
+++ b/tests/domain/buildPrompt.test.ts
@@ -106,6 +106,21 @@ describe('buildPrompt', () => {
 		expect(result.textInput).toBe('質問イントロ\n質問「今何時？」\n回答「');
 	});
 
+	it('normalizes the trigger message text in the inquiry branch, same as the normal dialogue path', async () => {
+		const messages: HumanMessage[] = [
+			{text: '@りんな 」ウナは「元気」と言った？', user: 'U1', ts: '1'},
+		];
+		const result = await buildPrompt(
+			messages,
+			'りんな',
+			{intro: 'イントロ', inquiryIntro: '質問イントロ'},
+			usernameMapping,
+			fakeTokenize,
+			now,
+		);
+		expect(result.formattedDialog).toBe('質問「ウナは『元気』と言った？」');
+	});
+
 	it('does not take the inquiry branch when no inquiryIntro is configured, even for a question', async () => {
 		const messages: HumanMessage[] = [{text: '今何時？', user: 'U1', ts: '1'}];
 		const result = await buildPrompt(


### PR DESCRIPTION
## Summary
- `buildPrompt` のinquiry分岐（`` `質問「${lastMessageText}」` `` を組み立てる箇所）は、通常のダイアログ整形パス（`buildFormattedMessages` が各メッセージに `normalizeText` を適用）と異なり、`lastMessageText` を一切正規化せず直接埋め込んでいた。
- これにより、メンション除去・Slackの `<...>` タグ除去に加え、#100 で対応した括弧の対応判定・鉤括弧の二重化変換もinquiry経路ではすべてスキップされており、`` `「`/`」` `` でユーザー入力を挟む同種のフォーマットに対して、直したはずの注入経路がこちらには残ったままだった。
- `lastMessageText` を埋め込む直前に `normalizeText` を通すよう修正。`isInquiryText` による末尾 `？`/`?` の判定自体は、`signalHandler.ts` の画像取得スコープ判定と同じ生テキストに対して行う挙動を維持している（変更していない）。

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm run lint`（変更ファイルに関して)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Che8DtJL1dCWjy4mA6M834